### PR TITLE
Fix TrustServiceUrl

### DIFF
--- a/BotFrameworkTwitterAdapter/TwitterConversationAdapter.cs
+++ b/BotFrameworkTwitterAdapter/TwitterConversationAdapter.cs
@@ -142,7 +142,11 @@ namespace BotFrameworkTwitterAdapter
                 From = new ChannelAccount(tweet.CreatedBy.IdStr, tweet.CreatedBy.ScreenName),
                 Recipient = new ChannelAccount(tweet.InReplyToUserIdStr, tweet.InReplyToScreenName),
                 Conversation = new ConversationAccount { Id = conversationId },
-                ChannelId = "twitter_conversation"
+                ChannelId = "twitter_conversation",
+                // Fix TrustServiceUrl
+                // https://github.com/microsoft/botbuilder-dotnet/blob/3a0dcfee003a7fcd0271c6336ab2c166f9a74313/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs#L368
+                // XXX どういう理由で ServiceUrl が求められているのか分かっていない
+                ServiceUrl = option.BotTwitterApiEndpoint,
             };
         }
 


### PR DESCRIPTION
https://github.com/microsoft/botbuilder-dotnet/blob/3a0dcfee003a7fcd0271c6336ab2c166f9a74313/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs#L368
XXX どういう理由で ServiceUrl が求められているのか分かっていない